### PR TITLE
Allow configuration override

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,12 +1,8 @@
 use Mix.Config
 
-bypass_port = 54321
-
-config :bypass, port: bypass_port
-
 config :pluggy_elixir,
   client_id: "test_client_id",
   client_secret: "test_client_secret",
   non_expiring_api_key: true,
   sandbox: true,
-  host: "http://localhost:#{bypass_port}"
+  host: "http://localhost:54321"

--- a/lib/pluggy_elixir/auth.ex
+++ b/lib/pluggy_elixir/auth.ex
@@ -20,32 +20,37 @@ defmodule PluggyElixir.Auth do
   The API Key is used to authenticate all requests to Pluggy API.
   """
 
-  @spec create_api_key :: {:ok, t()} | {:error, binary()}
-  def create_api_key do
-    build_api_key_params()
+  @spec create_api_key(Config.config_overrides() | Config.t()) :: {:ok, t()} | {:error, binary()}
+  def create_api_key(config_overrides \\ [])
+
+  def create_api_key(config_overrides) when is_list(config_overrides) do
+    config_overrides
+    |> Config.override()
+    |> create_api_key()
+  end
+
+  def create_api_key(%Config{} = config) do
+    config
+    |> build_api_key_params()
     |> perform_request()
     |> create_api_key_response()
   end
 
-  defp build_api_key_params do
-    with {:ok, client_id} <- Config.get_client_id(),
-         {:ok, client_secret} <- Config.get_client_secret() do
-      %{
-        clientId: client_id,
-        clientSecret: client_secret,
-        nonExpiring: Config.non_expiring_api_key()
-      }
-    end
+  defp build_api_key_params(%{auth: auth} = config) do
+    {config,
+     %{
+       clientId: auth.client_id,
+       clientSecret: auth.client_secret,
+       nonExpiring: auth.non_expiring_api_key
+     }}
   end
 
-  defp perform_request(params) when is_map(params), do: http_client().post(@auth_path, params)
-  defp perform_request(error), do: error
+  defp perform_request({%{adapter: %{module: http_adapter}} = config, request_body}),
+    do: http_adapter.post(@auth_path, request_body, config)
 
   defp create_api_key_response({:ok, %{status: 200, body: %{"apiKey" => api_key}}}),
     do: {:ok, %__MODULE__{api_key: api_key}}
 
   defp create_api_key_response({:ok, response}), do: {:error, Error.parse(response)}
   defp create_api_key_response(error), do: error
-
-  defp http_client, do: Config.get_http_adapter()
 end

--- a/lib/pluggy_elixir/http_adapter.ex
+++ b/lib/pluggy_elixir/http_adapter.ex
@@ -6,17 +6,19 @@ defmodule PluggyElixir.HttpAdapter do
   `PluggyElixir.HttpAdapter.Response` struct.
   """
 
+  alias PluggyElixir.Config
   alias PluggyElixir.HttpAdapter.Response
 
   @type url :: binary()
   @type body :: Response.body()
+  @type headers :: Response.headers()
   @type param :: binary() | [{binary() | atom(), param()}]
   @type query :: [{binary() | atom(), param()}]
   @type adapter_response :: {:ok, Response.t()} | {:error, binary()}
 
   @doc "Perform a HTTP request with GET method"
-  @callback get(url, query, Response.headers()) :: adapter_response()
+  @callback get(url, query, headers(), Config.t()) :: adapter_response()
 
   @doc "Perform a HTTP request with POST method"
-  @callback post(url, body(), query, Response.headers()) :: adapter_response()
+  @callback post(url, body(), query, headers(), Config.t()) :: adapter_response()
 end

--- a/lib/pluggy_elixir/http_adapter/tesla.ex
+++ b/lib/pluggy_elixir/http_adapter/tesla.ex
@@ -8,37 +8,39 @@ defmodule PluggyElixir.HttpAdapter.Tesla do
   @behaviour PluggyElixir.HttpAdapter
 
   @impl true
-  def post(url, body, query \\ [], headers \\ []) do
-    build_client()
-    |> Tesla.post(url, body, build_options(query, headers))
+  def post(url, body, query \\ [], headers \\ [], %Config{} = config) do
+    config
+    |> build_client()
+    |> Tesla.post(url, body, build_options(query, headers, config))
     |> format_response()
   end
 
   @impl true
-  def get(url, query \\ [], headers \\ []) do
-    build_client()
-    |> Tesla.get(url, build_options(query, headers))
+  def get(url, query \\ [], headers \\ [], %Config{} = config) do
+    config
+    |> build_client()
+    |> Tesla.get(url, build_options(query, headers, config))
     |> format_response()
   end
 
-  defp build_options(query, headers) do
+  defp build_options(query, headers, %{sandbox: sandbox}) do
     [
-      query: build_query(query),
+      query: build_query(query, sandbox),
       headers: headers
     ]
   end
 
-  defp build_query(query),
-    do: if(Config.sandbox(), do: Keyword.merge(query, sandbox: true), else: query)
+  defp build_query(query, true), do: Keyword.merge(query, sandbox: true)
+  defp build_query(query, _false), do: query
 
-  defp build_client do
+  defp build_client(config) do
     Tesla.client(
       [
-        {Tesla.Middleware.BaseUrl, host_uri()},
+        {Tesla.Middleware.BaseUrl, host_uri(config)},
         {Tesla.Middleware.Headers, [{"content-type", "application/json"}]},
         Tesla.Middleware.JSON
       ],
-      Keyword.fetch!(Config.get_http_adapter_config(), :adapter)
+      get_tesla_adapter(config)
     )
   end
 
@@ -53,5 +55,8 @@ defmodule PluggyElixir.HttpAdapter.Tesla do
 
   defp format_response({:error, reason}), do: {:error, inspect(reason)}
 
-  defp host_uri, do: to_string(Config.get_host_uri())
+  defp get_tesla_adapter(%{adapter: %{configs: adapter_config}}),
+    do: Keyword.fetch!(adapter_config, :adapter)
+
+  defp host_uri(%{host: host}), do: to_string(host)
 end

--- a/lib/pluggy_elixir/http_client.ex
+++ b/lib/pluggy_elixir/http_client.ex
@@ -8,53 +8,65 @@ defmodule PluggyElixir.HttpClient do
 
   @expired_msg "Missing or invalid authorization token"
 
-  @spec get(HttpAdapter.url(), HttpAdapter.query()) :: {:ok, Response.t()} | {:error, binary()}
-
-  def get(url, query \\ []), do: http_request(%{method: :get, url: url, query: query})
-
-  @spec post(HttpAdapter.url(), HttpAdapter.body(), HttpAdapter.query()) ::
+  @spec get(HttpAdapter.url(), HttpAdapter.query(), Config.t()) ::
           {:ok, Response.t()} | {:error, binary()}
 
-  def post(url, body, query \\ []),
-    do: http_request(%{method: :post, url: url, body: body, query: query})
+  def get(url, query \\ [], %Config{} = config),
+    do: http_request(%{method: :get, url: url, query: query}, config)
 
-  defp http_request(request) do
-    with %Auth{} = auth <- retrieve_auth(),
+  @spec post(HttpAdapter.url(), HttpAdapter.body(), HttpAdapter.query(), Config.t()) ::
+          {:ok, Response.t()} | {:error, binary()}
+
+  def post(url, body, query \\ [], %Config{} = config),
+    do: http_request(%{method: :post, url: url, body: body, query: query}, config)
+
+  defp http_request(request, config) do
+    with %Auth{} = auth <- retrieve_auth(config),
          authenticated <- authenticate(auth, request),
-         {:performed, response} <- perform_request(authenticated),
-         result <- return_or_retry(response, request) do
+         {:performed, response} <- perform_request(authenticated, config),
+         result <- return_or_retry(response, request, config) do
       handle_result(result)
     end
   end
 
-  defp return_or_retry({:ok, %Response{status: 403, body: %{"message" => @expired_msg}}}, request) do
-    with %Auth{} = auth <- renew_auth(),
+  defp return_or_retry(
+         {:ok, %Response{status: 403, body: %{"message" => @expired_msg}}},
+         request,
+         config
+       ) do
+    with %Auth{} = auth <- renew_auth(config),
          authenticated <- authenticate(auth, request),
-         {:performed, response} <- perform_request(authenticated) do
+         {:performed, response} <- perform_request(authenticated, config) do
       response
     end
   end
 
-  defp return_or_retry(return, _request), do: return
+  defp return_or_retry(return, _request, _config), do: return
 
   defp authenticate(%Auth{api_key: api_key}, request),
     do: Map.put(request, :headers, [{"X-API-KEY", api_key}])
 
-  defp perform_request(%{method: :get, url: url, query: query, headers: headers}),
-    do: {:performed, http_adapter().get(url, query, headers)}
+  defp perform_request(
+         %{method: :get, url: url, query: query, headers: headers},
+         %{adapter: %{module: http_adapter}} = config
+       ),
+       do: {:performed, http_adapter.get(url, query, headers, config)}
 
-  defp perform_request(%{method: :post, url: url, body: body, query: query, headers: headers}),
-    do: {:performed, http_adapter().post(url, body, query, headers)}
+  defp perform_request(
+         %{method: :post, url: url, body: body, query: query, headers: headers},
+         %{adapter: %{module: http_adapter}} = config
+       ),
+       do: {:performed, http_adapter.post(url, body, query, headers, config)}
 
-  defp retrieve_auth do
+  defp retrieve_auth(config) do
     case Guard.get_auth() do
       %Auth{} = auth -> auth
-      _any -> renew_auth()
+      _any -> renew_auth(config)
     end
   end
 
-  defp renew_auth do
-    case Auth.create_api_key() do
+  defp renew_auth(config) do
+    case Auth.create_api_key(config) do
       {:ok, auth} ->
         Guard.set_auth(auth)
         auth
@@ -73,6 +85,4 @@ defmodule PluggyElixir.HttpClient do
     do: {:error, Error.parse(response)}
 
   defp handle_result({:error, _reason} = error), do: error
-
-  defp http_adapter, do: Config.get_http_adapter()
 end

--- a/lib/pluggy_elixir/webhook.ex
+++ b/lib/pluggy_elixir/webhook.ex
@@ -3,7 +3,7 @@ defmodule PluggyElixir.Webhook do
   Handle webhooks actions.
   """
 
-  alias PluggyElixir.HttpClient
+  alias PluggyElixir.{Config, HttpClient}
 
   defstruct [:created_at, :event, :id, :updated_at, :url]
 
@@ -35,11 +35,11 @@ defmodule PluggyElixir.Webhook do
        ]}
   """
 
-  @spec all :: {:ok, [t()]} | {:error, PluggyElixir.Error.t()}
+  @spec all(Config.config_overrides()) :: {:ok, [t()]} | {:error, PluggyElixir.Error.t()}
 
-  def all do
+  def all(config_overrides \\ []) do
     @webhooks_path
-    |> HttpClient.get()
+    |> HttpClient.get(Config.override(config_overrides))
     |> handle_response()
   end
 

--- a/test/pluggy_elixir/config_test.exs
+++ b/test/pluggy_elixir/config_test.exs
@@ -1,107 +1,87 @@
 defmodule PluggyElixir.ConfigTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias PluggyElixir.Config
+  alias PluggyElixir.Config.{Adapter, Auth}
 
-  setup do
-    config = Application.get_all_env(:pluggy_elixir)
+  describe "override/1" do
+    test "when has a empty list to override return a %Config{} by config files" do
+      config = Config.override([])
 
-    on_exit(fn ->
-      Application.put_all_env(pluggy_elixir: config)
-    end)
-
-    :ok
-  end
-
-  describe "get_client_id/0" do
-    test "return configured client id" do
-      assert Config.get_client_id() == {:ok, "test_client_id"}
+      assert config ==
+               %Config{
+                 adapter: %Adapter{
+                   configs: [adapter: Tesla.Adapter.Hackney],
+                   module: PluggyElixir.HttpAdapter.Tesla
+                 },
+                 auth: %Auth{
+                   api_key: nil,
+                   client_id: "test_client_id",
+                   client_secret: "test_client_secret",
+                   non_expiring_api_key: true,
+                   scope: "pluggy_elixir"
+                 },
+                 host: %URI{
+                   authority: nil,
+                   fragment: nil,
+                   host: "localhost",
+                   path: nil,
+                   port: 54_321,
+                   query: nil,
+                   scheme: "http",
+                   userinfo: nil
+                 },
+                 sandbox: true
+               }
     end
 
-    test "return error if client_id is not configured" do
-      Application.delete_env(:pluggy_elixir, :client_id)
+    test "override config files and return a %Config{}" do
+      config =
+        Config.override(
+          host: "https://customhost.com:4334/api/v1",
+          sandbox: false,
+          client_id: "auth_client_id",
+          client_secret: "auth_client_secret",
+          non_expiring_api_key: false,
+          api_key: "already_created_api_key",
+          scope: "auth_scope_test"
+        )
 
-      assert Config.get_client_id() ==
-               {:error, "Missing PluggyElixir configuration: [ client_id ]"}
-    end
-  end
-
-  describe "get_client_secret/0" do
-    test "return configured client secret" do
-      assert Config.get_client_secret() == {:ok, "test_client_secret"}
-    end
-
-    test "return error if client_secret is not configured" do
-      Application.delete_env(:pluggy_elixir, :client_secret)
-
-      assert Config.get_client_secret() ==
-               {:error, "Missing PluggyElixir configuration: [ client_secret ]"}
-    end
-  end
-
-  describe "get_host_uri/0" do
-    test "return a URI struct by parsing configured value" do
-      assert Config.get_host_uri() == %URI{
-               scheme: "http",
-               host: "localhost",
-               port: 54_321
-             }
-    end
-
-    test "return default value when not configured" do
-      Application.delete_env(:pluggy_elixir, :host)
-
-      assert Config.get_host_uri() == %URI{
-               scheme: "https",
-               host: "api.pluggy.ai"
-             }
-    end
-
-    test "parse full url" do
-      Application.put_env(:pluggy_elixir, :host, "http://host.com:5000/api")
-
-      assert Config.get_host_uri() == %URI{
-               scheme: "http",
-               host: "host.com",
-               port: 5000,
-               path: "api"
-             }
-    end
-  end
-
-  describe "non_expiring_api_key/0" do
-    test "return configured value" do
-      assert Config.non_expiring_api_key() == true
+      assert config ==
+               %Config{
+                 adapter: %Adapter{
+                   configs: [adapter: Tesla.Adapter.Hackney],
+                   module: PluggyElixir.HttpAdapter.Tesla
+                 },
+                 auth: %Auth{
+                   api_key: "already_created_api_key",
+                   client_id: "auth_client_id",
+                   client_secret: "auth_client_secret",
+                   non_expiring_api_key: false,
+                   scope: "auth_scope_test"
+                 },
+                 host: %URI{
+                   authority: nil,
+                   fragment: nil,
+                   host: "customhost.com",
+                   path: "api/v1",
+                   port: 4334,
+                   query: nil,
+                   scheme: "https",
+                   userinfo: nil
+                 },
+                 sandbox: false
+               }
     end
 
-    test "return default value false when not configured" do
-      Application.delete_env(:pluggy_elixir, :non_expiring_api_key)
+    test "ensure boolean values" do
+      config =
+        Config.override(
+          sandbox: "non boolean vaue",
+          non_expiring_api_key: "null"
+        )
 
-      assert Config.non_expiring_api_key() == false
-    end
-
-    test "return default value false when configured value is invalid" do
-      Application.put_env(:pluggy_elixir, :non_expiring_api_key, "yes")
-
-      assert Config.non_expiring_api_key() == false
-    end
-  end
-
-  describe "sandbox/0" do
-    test "return configured value" do
-      assert Config.sandbox() == true
-    end
-
-    test "return default value false when not configured" do
-      Application.delete_env(:pluggy_elixir, :sandbox)
-
-      assert Config.sandbox() == false
-    end
-
-    test "return default value false when configured value is invalid" do
-      Application.put_env(:pluggy_elixir, :sandbox, "yes")
-
-      assert Config.sandbox() == false
+      assert %Config{sandbox: false, auth: %Auth{non_expiring_api_key: false}} = config
     end
   end
 end

--- a/test/pluggy_elixir/http_adapter/tesla_test.exs
+++ b/test/pluggy_elixir/http_adapter/tesla_test.exs
@@ -1,22 +1,15 @@
 defmodule PluggyElixir.HttpAdapter.TeslaTest do
-  use PluggyElixir.Case, async: false
+  use PluggyElixir.Case, async: true
 
+  alias PluggyElixir.Config
   alias PluggyElixir.HttpAdapter.{Response, Tesla}
-
-  setup do
-    config = Application.get_all_env(:pluggy_elixir)
-
-    on_exit(fn ->
-      Application.put_all_env(pluggy_elixir: config)
-    end)
-
-    :ok
-  end
 
   describe "post/4" do
     test "perform a post request and return status, body and headers", %{bypass: bypass} do
       url = "/auth"
       body = %{"key" => "value"}
+
+      config_overrides = Config.override(host: "http://localhost:#{bypass.port}")
 
       bypass_expect(bypass, "POST", url, fn conn ->
         assert conn.body_params == body
@@ -26,7 +19,7 @@ defmodule PluggyElixir.HttpAdapter.TeslaTest do
         |> Conn.resp(200, ~s<{"message": "ok"}>)
       end)
 
-      response = Tesla.post(url, body)
+      response = Tesla.post(url, body, [], config_overrides)
 
       assert {:ok,
               %Response{
@@ -43,18 +36,21 @@ defmodule PluggyElixir.HttpAdapter.TeslaTest do
       url = "/auth"
       query = [custom: "custom-value"]
 
+      config_overrides = Config.override(host: "http://localhost:#{bypass.port}")
+
       bypass_expect(bypass, "POST", url, fn conn ->
         assert conn.query_params == %{"sandbox" => "true", "custom" => "custom-value"}
 
         Conn.resp(conn, 200, ~s<{"message": "ok"}>)
       end)
 
-      assert {:ok, %Response{}} = Tesla.post(url, %{}, query)
+      assert {:ok, %Response{}} = Tesla.post(url, %{}, query, config_overrides)
     end
 
     test "sending custom headers", %{bypass: bypass} do
       url = "/auth"
       headers = [{"custom-header", "custom-value"}]
+      config_overrides = Config.override(host: "http://localhost:#{bypass.port}")
 
       bypass_expect(bypass, "POST", url, fn conn ->
         assert Enum.any?(headers, fn header -> [header] == headers end) == true
@@ -62,13 +58,12 @@ defmodule PluggyElixir.HttpAdapter.TeslaTest do
         Conn.resp(conn, 200, ~s<{"message": "ok"}>)
       end)
 
-      assert {:ok, %Response{}} = Tesla.post(url, %{}, [], headers)
+      assert {:ok, %Response{}} = Tesla.post(url, %{}, [], headers, config_overrides)
     end
 
     test "send query sandbox as true when sandbox is configured", %{bypass: bypass} do
-      Application.put_env(:pluggy_elixir, :sandbox, true)
-
       url = "/auth"
+      config_overrides = Config.override(host: "http://localhost:#{bypass.port}", sandbox: true)
 
       bypass_expect(bypass, "POST", url, fn conn ->
         assert conn.query_params == %{"sandbox" => "true"}
@@ -76,13 +71,12 @@ defmodule PluggyElixir.HttpAdapter.TeslaTest do
         Conn.resp(conn, 200, ~s<{"message": "ok"}>)
       end)
 
-      assert {:ok, %Response{}} = Tesla.post(url, %{})
+      assert {:ok, %Response{}} = Tesla.post(url, %{}, [], config_overrides)
     end
 
     test "don't send query sandbox when sandbox is configured to false", %{bypass: bypass} do
-      Application.put_env(:pluggy_elixir, :sandbox, false)
-
       url = "/auth"
+      config_overrides = Config.override(host: "http://localhost:#{bypass.port}", sandbox: false)
 
       bypass_expect(bypass, "POST", url, fn conn ->
         assert conn.query_params == %{}
@@ -90,59 +84,66 @@ defmodule PluggyElixir.HttpAdapter.TeslaTest do
         Conn.resp(conn, 200, ~s<{"message": "ok"}>)
       end)
 
-      assert {:ok, %Response{}} = Tesla.post(url, %{})
+      assert {:ok, %Response{}} = Tesla.post(url, %{}, [], config_overrides)
     end
 
     test "return success even when response status is a client error", %{bypass: bypass} do
       url = "/auth"
+      config_overrides = Config.override(host: "http://localhost:#{bypass.port}")
 
       bypass_expect(bypass, "POST", url, fn conn ->
         Conn.resp(conn, 422, ~s<{"error": "fail"}>)
       end)
 
-      assert {:ok, %Response{status: 422, body: %{"error" => "fail"}}} = Tesla.post(url, %{})
+      assert {:ok, %Response{status: 422, body: %{"error" => "fail"}}} =
+               Tesla.post(url, %{}, [], config_overrides)
     end
 
     test "return success even when response status is a server error", %{bypass: bypass} do
       url = "/auth"
+      config_overrides = Config.override(host: "http://localhost:#{bypass.port}")
 
       bypass_expect(bypass, "POST", url, fn conn ->
         Conn.resp(conn, 500, ~s<{"error": "fail"}>)
       end)
 
-      assert {:ok, %Response{status: 500, body: %{"error" => "fail"}}} = Tesla.post(url, %{})
+      assert {:ok, %Response{status: 500, body: %{"error" => "fail"}}} =
+               Tesla.post(url, %{}, [], config_overrides)
     end
 
     test "return error when response isn't a valid json", %{bypass: bypass} do
       url = "/auth"
+      config_overrides = Config.override(host: "http://localhost:#{bypass.port}")
 
       bypass_expect(bypass, "POST", url, fn conn ->
         Conn.resp(conn, 200, ~s<not a valid json>)
       end)
 
-      assert Tesla.post(url, %{}) == {:error, "response body is not a valid JSON"}
+      assert Tesla.post(url, %{}, [], config_overrides) ==
+               {:error, "response body is not a valid JSON"}
     end
 
     test "return error when server is down", %{bypass: bypass} do
       url = "/auth"
+      config_overrides = Config.override(host: "http://localhost:#{bypass.port}")
 
       Bypass.down(bypass)
 
-      assert Tesla.post(url, %{}) == {:error, "econnrefused"}
+      assert Tesla.post(url, %{}, [], config_overrides) == {:error, "econnrefused"}
     end
 
     test "return error when can't resolve hostname" do
-      Application.put_env(:pluggy_elixir, :host, "invalid.host.ex")
-
       url = "/auth"
+      config_overrides = Config.override(host: "invalid.host.ex")
 
-      assert Tesla.post(url, %{}) == {:error, "nxdomain"}
+      assert Tesla.post(url, %{}, config_overrides) == {:error, "nxdomain"}
     end
   end
 
   describe "get/3" do
     test "perform a get request and return status, body and headers", %{bypass: bypass} do
       url = "/auth"
+      config_overrides = Config.override(host: "http://localhost:#{bypass.port}")
 
       bypass_expect(bypass, "GET", url, fn conn ->
         conn
@@ -150,7 +151,7 @@ defmodule PluggyElixir.HttpAdapter.TeslaTest do
         |> Conn.resp(200, ~s<{"message": "ok"}>)
       end)
 
-      response = Tesla.get(url)
+      response = Tesla.get(url, config_overrides)
 
       assert {:ok,
               %Response{
@@ -166,6 +167,7 @@ defmodule PluggyElixir.HttpAdapter.TeslaTest do
     test "sending a custom query", %{bypass: bypass} do
       url = "/auth"
       query = [custom: "custom-value"]
+      config_overrides = Config.override(host: "http://localhost:#{bypass.port}")
 
       bypass_expect(bypass, "GET", url, fn conn ->
         assert conn.query_params == %{"sandbox" => "true", "custom" => "custom-value"}
@@ -173,12 +175,13 @@ defmodule PluggyElixir.HttpAdapter.TeslaTest do
         Conn.resp(conn, 200, ~s<{"message": "ok"}>)
       end)
 
-      assert {:ok, %Response{}} = Tesla.get(url, query)
+      assert {:ok, %Response{}} = Tesla.get(url, query, config_overrides)
     end
 
     test "sending custom headers", %{bypass: bypass} do
       url = "/auth"
       headers = [{"custom-headers", "custom-value"}]
+      config_overrides = Config.override(host: "http://localhost:#{bypass.port}")
 
       bypass_expect(bypass, "GET", url, fn conn ->
         assert Enum.any?(headers, fn header -> [header] == headers end) == true
@@ -186,13 +189,12 @@ defmodule PluggyElixir.HttpAdapter.TeslaTest do
         Conn.resp(conn, 200, ~s<{"message": "ok"}>)
       end)
 
-      assert {:ok, %Response{}} = Tesla.get(url, [], headers)
+      assert {:ok, %Response{}} = Tesla.get(url, [], headers, config_overrides)
     end
 
     test "send query sandbox as true when sandbox is configured", %{bypass: bypass} do
-      Application.put_env(:pluggy_elixir, :sandbox, true)
-
       url = "/auth"
+      config_overrides = Config.override(host: "http://localhost:#{bypass.port}", sandbox: true)
 
       bypass_expect(bypass, "GET", url, fn conn ->
         assert conn.query_params == %{"sandbox" => "true"}
@@ -200,13 +202,12 @@ defmodule PluggyElixir.HttpAdapter.TeslaTest do
         Conn.resp(conn, 200, ~s<{"message": "ok"}>)
       end)
 
-      assert {:ok, %Response{}} = Tesla.get(url)
+      assert {:ok, %Response{}} = Tesla.get(url, config_overrides)
     end
 
     test "don't send query sandbox when sandbox is configured to false", %{bypass: bypass} do
-      Application.put_env(:pluggy_elixir, :sandbox, false)
-
       url = "/auth"
+      config_overrides = Config.override(host: "http://localhost:#{bypass.port}", sandbox: false)
 
       bypass_expect(bypass, "GET", url, fn conn ->
         assert conn.query_params == %{}
@@ -214,53 +215,58 @@ defmodule PluggyElixir.HttpAdapter.TeslaTest do
         Conn.resp(conn, 200, ~s<{"message": "ok"}>)
       end)
 
-      assert {:ok, %Response{}} = Tesla.get(url)
+      assert {:ok, %Response{}} = Tesla.get(url, config_overrides)
     end
 
     test "return success even when response status is a client error", %{bypass: bypass} do
       url = "/auth"
+      config_overrides = Config.override(host: "http://localhost:#{bypass.port}")
 
       bypass_expect(bypass, "GET", url, fn conn ->
         Conn.resp(conn, 422, ~s<{"error": "fail"}>)
       end)
 
-      assert {:ok, %Response{status: 422, body: %{"error" => "fail"}}} = Tesla.get(url)
+      assert {:ok, %Response{status: 422, body: %{"error" => "fail"}}} =
+               Tesla.get(url, config_overrides)
     end
 
     test "return success even when response status is a server error", %{bypass: bypass} do
       url = "/auth"
+      config_overrides = Config.override(host: "http://localhost:#{bypass.port}")
 
       bypass_expect(bypass, "GET", url, fn conn ->
         Conn.resp(conn, 500, ~s<{"error": "fail"}>)
       end)
 
-      assert {:ok, %Response{status: 500, body: %{"error" => "fail"}}} = Tesla.get(url)
+      assert {:ok, %Response{status: 500, body: %{"error" => "fail"}}} =
+               Tesla.get(url, config_overrides)
     end
 
     test "return error when response isn't a valid json", %{bypass: bypass} do
       url = "/auth"
+      config_overrides = Config.override(host: "http://localhost:#{bypass.port}")
 
       bypass_expect(bypass, "GET", url, fn conn ->
         Conn.resp(conn, 200, ~s<not a valid json>)
       end)
 
-      assert Tesla.get(url) == {:error, "response body is not a valid JSON"}
+      assert Tesla.get(url, config_overrides) == {:error, "response body is not a valid JSON"}
     end
 
     test "return error when server is down", %{bypass: bypass} do
       url = "/auth"
+      config_overrides = Config.override(host: "http://localhost:#{bypass.port}")
 
       Bypass.down(bypass)
 
-      assert Tesla.get(url) == {:error, "econnrefused"}
+      assert Tesla.get(url, config_overrides) == {:error, "econnrefused"}
     end
 
     test "return error when can't resolve hostname" do
-      Application.put_env(:pluggy_elixir, :host, "invalid.host.ex")
-
       url = "/auth"
+      config_overrides = Config.override(host: "invalid.host.ex")
 
-      assert Tesla.get(url) == {:error, "nxdomain"}
+      assert Tesla.get(url, config_overrides) == {:error, "nxdomain"}
     end
   end
 end

--- a/test/pluggy_elixir/webhook_test.exs
+++ b/test/pluggy_elixir/webhook_test.exs
@@ -8,6 +8,8 @@ defmodule PluggyElixir.WebhookTest do
     test "return all created webhooks", %{bypass: bypass} do
       create_and_save_api_key()
 
+      config_overrides = [host: "http://localhost:#{bypass.port}"]
+
       bypass_expect(bypass, "GET", "/webhooks", fn conn ->
         Conn.resp(
           conn,
@@ -16,7 +18,7 @@ defmodule PluggyElixir.WebhookTest do
         )
       end)
 
-      assert {:ok, webhooks} = Webhook.all()
+      assert {:ok, webhooks} = Webhook.all(config_overrides)
 
       assert webhooks == [
                %PluggyElixir.Webhook{
@@ -31,24 +33,27 @@ defmodule PluggyElixir.WebhookTest do
 
     test "return an empty list when there is not webhook created", %{bypass: bypass} do
       create_and_save_api_key()
+      config_overrides = [host: "http://localhost:#{bypass.port}"]
 
       bypass_expect(bypass, "GET", "/webhooks", fn conn ->
         Conn.resp(conn, 200, ~s<{"results":[]}>)
       end)
 
-      assert {:ok, webhooks} = Webhook.all()
+      assert {:ok, webhooks} = Webhook.all(config_overrides)
 
       assert webhooks == []
     end
 
     test "when has error to get webhook list, returns that error", %{bypass: bypass} do
       create_and_save_api_key()
+      config_overrides = [host: "http://localhost:#{bypass.port}"]
 
       bypass_expect(bypass, "GET", "/webhooks", fn conn ->
         Conn.resp(conn, 500, ~s<{"message":"Internal Server Error"}>)
       end)
 
-      assert Webhook.all() == {:error, %Error{message: "Internal Server Error", code: 500}}
+      assert Webhook.all(config_overrides) ==
+               {:error, %Error{message: "Internal Server Error", code: 500}}
     end
   end
 end

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -16,7 +16,7 @@ defmodule PluggyElixir.Case do
   end
 
   setup _tags do
-    bypass = Bypass.open(port: Application.fetch_env!(:bypass, :port))
+    bypass = Bypass.open()
 
     {:ok, bypass: bypass}
   end


### PR DESCRIPTION
## Motivation
Allow the user override the configuration when using client functions. It's useful to help us testing our lib

## Proposed solution
- Created the function `override` in `PluggyElixir.Config` to override `Application` configs with given config list (Keyword).
- Internally uses `Config` struct generated by `override/1` to access configuration.
- Add doc about config override.
