### PR TITLE
Bump CI OS version to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   mix_format:
     name: mix format (Elixir 1.11.3 OTP 23.3)
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - uses: erlef/setup-elixir@v1
@@ -23,7 +23,7 @@ jobs:
 
   mix_credo:
     name: mix credo (Elixir 1.11.3 OTP 23.3)
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - uses: erlef/setup-elixir@v1
@@ -47,7 +47,7 @@ jobs:
             otp: "22.3"
           - elixir: "1.11.3"
             otp: "23.3"
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - uses: erlef/setup-elixir@v1
@@ -61,7 +61,7 @@ jobs:
 
   coverage:
     name: Check coverage
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     needs: [mix_format, mix_credo, mix_test]
     steps:
       - uses: actions/checkout@v1
@@ -80,7 +80,7 @@ jobs:
   # Check version is disabled
   mix_check_version:
     name: Check version (Elixir 1.11.3 OTP 23.3)
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     needs: [mix_format, mix_credo, mix_test]
     if: false && github.ref != 'refs/heads/main' && github.event_name == 'pull_request' && github.base_ref == 'main'
     steps:
@@ -99,7 +99,7 @@ jobs:
   # Publish is disabled
   mix_publish:
     name: Publish (Elixir 1.10.2 OTP 22.3)
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     needs: [mix_format, mix_credo, mix_test]
     outputs:
       version: ${{ steps.output_version.outputs.version }}
@@ -123,7 +123,7 @@ jobs:
   # Release is disabled
   github_release:
     name: Create release
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     needs: [mix_publish]
     if: false && github.ref == 'refs/heads/main'
     steps:


### PR DESCRIPTION
## Motivation

pluggy_elixir's CI seems frozen since the specified OS version is no longer in this org (as before in brainn org)
![image](https://user-images.githubusercontent.com/16140783/148266756-29e84a24-0bfe-4045-acc4-9040c5f185dc.png)

## Proposed solution

bump the CI's OS version as in [strong_params](https://github.com/Finbits/strong_params/blob/main/.github/workflows/ci.yml) to `ubuntu-latest`
